### PR TITLE
docs(ai_assistant): économie de tokens + ACL outils MCP

### DIFF
--- a/plugin-ai_assistant/en_US/index.md
+++ b/plugin-ai_assistant/en_US/index.md
@@ -208,12 +208,50 @@ Actions scheduled via `schedule_action` (e.g. *"turn off the living room in 30 m
 
 ---
 
+# Cost optimization (token economy)
+
+The plugin automatically reduces the number of tokens sent on each message, without degrading home-automation use cases. These optimizations are enabled by default and tunable per device (the `tools/list` cache is global).
+
+| Option | Purpose | Values | Default |
+|---|---|---|---|
+| `mcp_tools_prompt_mode` | MCP tools injection into the prompt | `auto` / `always` / `never` | `auto` |
+| `mcpMaxTools` | Max MCP tools sent to the model (relevance selection) | integer (`0` = unlimited) | `28` |
+| `mcp_tools_cache_ttl` | `tools/list` cache duration per MCP server (seconds) | integer (`0` = disabled) | `21600` (6 h) |
+| `jeedom_context_mode` | Injected Jeedom context (jeeAssist) | `auto` (filtered by the question) / `full` | `auto` |
+
+Mechanisms:
+
+- **`tools/list` cache**: a server's tool list is no longer reloaded on every message. Use *Refresh tools/list* in the MCP modal to force a refresh.
+- **Compact catalog + tool selection**: only relevant tools (question keywords) are sent, with truncated descriptions — instead of dozens of full schemas.
+- **Tool-less mode**: a conversational question (*"summarize our discussion"*, *"explain this option"*) sends no tools and no `tools/list` call; a home request (*"turn on the living room"*) keeps the tools.
+- **Filtered Jeedom context**: in jeeAssist, only devices related to the question are injected. A global request (*"list all my devices"*, *"home overview"*) receives the full context.
+- **History compression**: beyond a threshold, older exchanges are summarized by a small model.
+- **User memory**: useful facts (preferences) are stored separately (`dataStore`) and injected selectively, not via the whole history.
+- **Prompt caching**: leverages provider prompt caching (Claude, OpenAI/DeepSeek, Gemini). The share of tokens served from cache is tracked (`cached_tokens`) in the `[tokens]` debug logs.
+
+> The `always` / `full` / TTL `0` escape hatches fully restore the original behavior if needed.
+
+---
+
 # Security
+
+## General safeguards
 
 - **Whitelists**: fine-grained control of authorized commands
 - **Read-only mode** recommended for testing
 - **Confirmations for sensitive actions** (according to configuration)
 - **Atomic writes** (tmp + rename) on `scheduled_actions.json`, `whitelist.json`, `tool_call_audit.json`
+
+## MCP tool ACL
+
+Each MCP client device enforces level-based access control, independent of the connected server:
+
+- **`read` / `write` / `execute` levels**: enabled separately per device. A tool is auto-classified by name (`get_`/`list_`/`read_` = read; `set_`/`create_`/`update_` = write; `exec_`/`run_`/`trigger_`/`send_` = execute).
+- **Destructive guard**: deletion / purge / shell-execution tools (`delete_`, `purge_`, `exec_shell`...) are **denied by default** — explicit opt-in required per device (*Allow destructive actions*).
+- **Confirmation** of sensitive actions before execution (lock, alarm, gate...).
+- **Real-time preview** (SSE) of side-effect actions, shown before execution.
+- **Full audit**: every tool call (goal, arguments, decision, status) is logged in `tool_call_audit.json`.
+- **Explicit denial returned to the model**: if a tool is blocked by ACL, the AI receives the error and can adapt rather than fail.
 
 ---
 

--- a/plugin-ai_assistant/en_US/index.md
+++ b/plugin-ai_assistant/en_US/index.md
@@ -19,6 +19,42 @@ pluginId: ai_assistant
 >
 > This last use is a small revolution. Beyond the practical aspect, the possibilities become unlimited: imagine a Jeedom scenario asking the AI to generate and integrate a complex script, all internally and autonomously.
 
+## At a glance
+
+- **9+ interchangeable providers**: Claude, Gemini, OpenAI, DeepSeek, Mistral, Groq, xAI, OpenRouter, Perplexity, Ollama — with **automatic fallback**.
+- **MCP home-automation agent**: the AI calls tools to read the real state then act (multi-step loop: read → decide → act → verify).
+- **3 modes**: pure chat (`provider`), native Jeedom assistant (`jeeAssist`), MCP agent (`mcp_client` — jeedom or third-party such as Home Assistant).
+- **Real security**: read/write/execute ACL, destructive actions denied by default, confirmation of sensitive actions, real-time preview, full audit.
+- **Automatable**: triggerable from scenarios, voice interactions, events, cron.
+- **Cost-efficient**: `tools/list` cache + prompt caching, tool selection, tool-less mode, filtered home context, history compression, user memory.
+- **Local & multimodal**: hosted on your Jeedom, image (camera) and document analysis, desktop / mobile / PWA access.
+
+## When to use it (vs a classic AI client)
+
+The AI model is the same as everywhere — what changes is **where it is plugged in** and **what it can do**: knowledge of your home, the power to act, and the safeguards to do so safely. These are **complementary** tools.
+
+| You want to… | Use |
+|---|---|
+| Code, long general-purpose tasks | A dedicated client (Codex, ChatGPT…) |
+| Understand and **control your home** | **ai_assistant + MCP** |
+| An AI triggered by a **scenario / voice** | **ai_assistant** |
+| Act on devices **safely** | **ai_assistant** (ACL + confirmation) |
+| Avoid depending on a single vendor | **ai_assistant** (multi-provider + fallback) |
+
+### Examples
+
+```text
+"Why isn't the heating warming the bedroom?"
+   → reads setpoint + temperature + history, explains the cause.
+
+"Get the house ready for the night."
+   → checks openings, lowers setpoints, runs the scenario
+     (with confirmation if the action is sensitive).
+
+[Triggered by Jeedom] abnormal consumption detected
+   → the AI analyzes the faulty device and proposes a fix.
+```
+
 ---
 
 # Why add mcp_jeedom?

--- a/plugin-ai_assistant/fr_FR/changelog.md
+++ b/plugin-ai_assistant/fr_FR/changelog.md
@@ -41,9 +41,10 @@ lang: fr_FR
 
 > Échappatoires `always` / `full` / TTL `0` pour restaurer le comportement d'origine.
 
-### 🔒 Documentation sécurité MCP
+### 📚 Documentation
 
-- Détail des **ACL d'outils MCP** (niveaux `read`/`write`/`execute`), du **garde-fou destructif** (refus par défaut), de la **confirmation** des actions sensibles, de l'**aperçu temps réel** (SSE) et de l'**audit** (`tool_call_audit.json`).
+- **Présentation enrichie** : « En bref » (capacités clés), tableau *Quand l'utiliser (vs un client IA classique)* et exemples concrets.
+- **Sécurité MCP détaillée** : **ACL d'outils** (niveaux `read`/`write`/`execute`), **garde-fou destructif** (refus par défaut), **confirmation** des actions sensibles, **aperçu temps réel** (SSE) et **audit** (`tool_call_audit.json`).
 
 ## 19/04/2026
 

--- a/plugin-ai_assistant/fr_FR/changelog.md
+++ b/plugin-ai_assistant/fr_FR/changelog.md
@@ -19,6 +19,7 @@ lang: fr_FR
 
 ## Sommaire
 
+- [29/05/2026](#29052026)
 - [19/04/2026](#19042026)
 - [18/04/2026](#18042026)
 - [17/04/2026](#17042026)
@@ -27,6 +28,22 @@ lang: fr_FR
 - [20/03/2026](#20032026)
 - [31/12/2025](#31122025)
 - [21/12/2025](#21122025)
+
+## 29/05/2026
+
+### ⚡ Optimisation des coûts (économie de tokens)
+
+- **Cache `tools/list`** par serveur MCP (`mcp_tools_cache_ttl`, défaut 6 h) : la liste des outils n'est plus rechargée à chaque message. Bouton *Actualiser tools/list* dans le modal MCP pour forcer le refresh.
+- **Sélection d'outils par pertinence + catalogue compact** (`mcpMaxTools`, défaut 28) : seuls les outils utiles à la question sont envoyés, descriptions tronquées — désormais sur **tous** les providers (plus seulement Gemini).
+- **Mode sans-outils** (`mcp_tools_prompt_mode = auto|always|never`) : une question conversationnelle (*"résume notre discussion"*) n'envoie aucun outil ni appel `tools/list` ; une demande domotique garde les outils.
+- **Contexte Jeedom filtré** par la question en jeeAssist (`jeedom_context_mode = auto|full`) : seuls les équipements liés à la demande sont injectés ; les demandes globales reçoivent le contexte complet.
+- **Suivi du cache de prompt** : la part de tokens servie depuis le cache fournisseur (Claude, OpenAI/DeepSeek, Gemini) est tracée (`cached_tokens`) dans les logs debug `[tokens]`.
+
+> Échappatoires `always` / `full` / TTL `0` pour restaurer le comportement d'origine.
+
+### 🔒 Documentation sécurité MCP
+
+- Détail des **ACL d'outils MCP** (niveaux `read`/`write`/`execute`), du **garde-fou destructif** (refus par défaut), de la **confirmation** des actions sensibles, de l'**aperçu temps réel** (SSE) et de l'**audit** (`tool_call_audit.json`).
 
 ## 19/04/2026
 

--- a/plugin-ai_assistant/fr_FR/index.md
+++ b/plugin-ai_assistant/fr_FR/index.md
@@ -19,6 +19,42 @@ pluginId: ai_assistant
 >
 > Ce dernier usage est une petite revolution. Au dela de l aspect pratique, les possibilites deviennent illimitees : imaginez un scenario Jeedom demandant a l IA de generer et d integrer un script complexe, le tout en interne et de maniere autonome.
 
+## En bref
+
+- **9+ providers** interchangeables : Claude, Gemini, OpenAI, DeepSeek, Mistral, Groq, xAI, OpenRouter, Perplexity, Ollama — avec **fallback automatique**.
+- **Agent domotique MCP** : l IA appelle des outils pour lire l etat reel puis agir (boucle multi-etapes : lire → decider → agir → verifier).
+- **3 modes** : chat pur (`provider`), assistant Jeedom natif (`jeeAssist`), agent MCP (`mcp_client` — jeedom ou tiers comme Home Assistant).
+- **Securite reelle** : ACL read/write/execute, refus des actions destructives par defaut, confirmation des actions sensibles, apercu temps reel, audit complet.
+- **Automatisable** : declenchable depuis scenarios, interactions vocales, evenements, cron.
+- **Econome** : cache `tools/list` + cache de prompt, selection d outils, mode sans-outils, contexte domotique filtre, compression d historique, memoire utilisateur.
+- **Local & multimodal** : heberge sur votre Jeedom, analyse d images (cameras) et documents, acces desktop / mobile / PWA.
+
+## Quand l utiliser (vs un client IA classique)
+
+Le modele d IA est le meme que partout — ce qui change, c est **ou il est branche** et **ce qu il peut faire** : la connaissance de votre maison, le pouvoir d agir, et les garde-fous pour le faire sans danger. Ce sont des outils **complementaires**.
+
+| Vous voulez… | Utilisez |
+|---|---|
+| Coder, taches generalistes longues | Un client dedie (Codex, ChatGPT…) |
+| Comprendre et **piloter votre maison** | **ai_assistant + MCP** |
+| Une IA declenchee par un **scenario / la voix** | **ai_assistant** |
+| Agir sur des equipements **en securite** | **ai_assistant** (ACL + confirmation) |
+| Ne pas dependre d un seul fournisseur | **ai_assistant** (multi-provider + fallback) |
+
+### Exemples
+
+```text
+« Pourquoi le chauffage ne chauffe pas dans la chambre ? »
+   → lit consigne + temperature + historique, explique la cause.
+
+« Prepare la maison pour la nuit. »
+   → verifie ouvertures, baisse les consignes, lance le scenario
+     (avec confirmation si action sensible).
+
+[Declenche par Jeedom] conso anormale detectee
+   → l IA analyse l equipement fautif et propose une correction.
+```
+
 ---
 
 # Pourquoi ajouter mcp_jeedom ?

--- a/plugin-ai_assistant/fr_FR/index.md
+++ b/plugin-ai_assistant/fr_FR/index.md
@@ -293,13 +293,51 @@ Les actions programmees via `schedule_action` (ex: *"eteins le salon dans 30 min
 
 ---
 
+# Optimisation des couts (economie de tokens)
+
+Le plugin reduit automatiquement le nombre de tokens envoyes a chaque message, sans degrader les usages domotiques. Ces optimisations sont actives par defaut et reglables par equipement (le cache `tools/list` est global).
+
+| Option | Role | Valeurs | Defaut |
+|---|---|---|---|
+| `mcp_tools_prompt_mode` | Injection des outils MCP dans le prompt | `auto` / `always` / `never` | `auto` |
+| `mcpMaxTools` | Nb max d outils MCP envoyes au modele (selection par pertinence) | entier (`0` = illimite) | `28` |
+| `mcp_tools_cache_ttl` | Duree du cache de la liste `tools/list` par serveur MCP (secondes) | entier (`0` = desactive) | `21600` (6 h) |
+| `jeedom_context_mode` | Contexte Jeedom injecte (jeeAssist) | `auto` (filtre par la question) / `full` | `auto` |
+
+Mecanismes :
+
+- **Cache `tools/list`** : la liste des outils d un serveur MCP n est plus rechargee a chaque message. Bouton *Actualiser tools/list* dans le modal MCP pour forcer le refresh.
+- **Catalogue compact + selection d outils** : seuls les outils pertinents (mots-cles de la question) sont envoyes, descriptions tronquees — au lieu de dizaines de schemas complets.
+- **Mode sans-outils** : une question conversationnelle (*"resume notre discussion"*, *"explique cette option"*) n envoie aucun outil ni appel `tools/list` ; une demande domotique (*"allume le salon"*) garde les outils.
+- **Contexte Jeedom filtre** : en jeeAssist, seuls les equipements lies a la question sont injectes. Une demande globale (*"liste tous mes equipements"*, *"recapitulatif de la maison"*) recoit le contexte complet.
+- **Compression d historique** : au-dela d un seuil, les anciens echanges sont resumes par un mini-modele.
+- **Memoire utilisateur** : les faits utiles (preferences) sont stockes a part (`dataStore`) et injectes de facon ciblee, pas via tout l historique.
+- **Cache de prompt** : exploite le prompt caching des fournisseurs (Claude, OpenAI/DeepSeek, Gemini). La part de tokens servie depuis le cache est tracee (`cached_tokens`) dans les logs debug `[tokens]`.
+
+> Les echappatoires `always` / `full` / TTL `0` restaurent integralement le comportement d origine si besoin.
+
+---
+
 # Securite
+
+## Gardes-fous generaux
 
 - **Whitelists** : controle fin des commandes autorisees — les tools natifs passent par les memes `_execAllowed*` que le protocole legacy
 - **Mode lecture seule** recommande pour tests
 - **Confirmations d actions sensibles** (selon configuration)
 - **Ecritures atomiques** (tmp + rename) sur `scheduled_actions.json`, `whitelist.json`, `tool_call_audit.json` pour resister a un crash mid-write
 - **Source de verite unique** : les modeles et endpoints sont lus depuis `core/config/ai_models.json` et `ai_assistant::PROVIDER_ENDPOINTS` — plus de divergence entre le code et le catalogue
+
+## ACL des outils MCP
+
+Chaque equipement client MCP applique un controle d acces par niveau, independamment du serveur connecte :
+
+- **Niveaux `read` / `write` / `execute`** : actives separement par equipement. Un outil est classe automatiquement d apres son nom (`get_`/`list_`/`read_` = read ; `set_`/`create_`/`update_` = write ; `exec_`/`run_`/`trigger_`/`send_` = execute).
+- **Garde-fou destructif** : les outils de suppression / purge / execution shell (`delete_`, `purge_`, `exec_shell`...) sont **refuses par defaut** — activation explicite requise par equipement (*Autoriser actions destructives*).
+- **Confirmation** des actions sensibles avant execution (serrure, alarme, portail...).
+- **Apercu temps reel** (SSE) des actions a effet de bord, affiche avant leur execution.
+- **Audit complet** : chaque appel d outil (objectif, arguments, decision, statut) est trace dans `tool_call_audit.json`.
+- **Refus explicite renvoye au modele** : si un outil est bloque par l ACL, l IA recoit l erreur et peut s adapter plutot que d echouer.
 
 ---
 


### PR DESCRIPTION
## Mise à jour de la doc `plugin-ai_assistant`

### Ajouts (FR + EN)
- **Section « Optimisation des coûts (économie de tokens) »** : mode sans-outils, cache `tools/list`, sélection d'outils multi-provider + catalogue compact, contexte Jeedom filtré, cache de prompt (`cached_tokens`). Tableau des options : `mcp_tools_prompt_mode`, `mcpMaxTools`, `mcp_tools_cache_ttl`, `jeedom_context_mode` (avec leurs défauts et échappatoires).
- **Section Sécurité enrichie** : ACL d'outils MCP (`read`/`write`/`execute`), garde-fou destructif (refus par défaut), confirmation des actions sensibles, aperçu temps réel (SSE), audit (`tool_call_audit.json`).
- **Changelog FR** : entrée `29/05/2026`.

Purement additif (93 lignes ajoutées, 0 suppression). Reflète les fonctionnalités implémentées dans le plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)